### PR TITLE
AUR 4.0.0 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ ATTRIBUTES
 
 | Attribute                    | Default                                   | Description                                             |
 |------------------------------|-------------------------------------------|---------------------------------------------------------|
-| `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
-| `node[:pacman][:build_user]` | `nobody`                                    | The user that will build AUR packages.                  |
+| `node['pacman']['build_dir']`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| `node['pacman']['build_user']` | `nobody`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========
@@ -41,7 +41,7 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 ### Parameters:
 
 * version - hardcode a version
-* builddir - specify an alternate build directory, defaults to `node[:pacman][:build_dir]`.
+* builddir - specify an alternate build directory, defaults to `node['pacman']['build_dir']`.
 * options - pass arbitrary options to the pacman command.
 * `pkgbuild_src` - whether to use an included PKGBUILD file, put the PKGBUILD file in in the `files/default` directory.
 * patches - array of patch names, as files in `files/default` that should be applied for the package.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
-default[:pacman][:build_user] = "nobody"
+default['pacman']['build_dir'] = "#{Chef::Config[:file_cache_path]}/builds"
+default['pacman']['build_user'] = 'nobody'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.0"
+version          "2.0.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.1"
+version          "2.0.0"

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -39,7 +39,7 @@ action :build do
 
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
-      source "https://aur.archlinux.org/packages/#{package_namespace}/#{new_resource.name}/#{new_resource.name}.tar.gz"
+      source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
       owner node[:pacman][:build_user]
       group node[:pacman][:build_user]
       mode 0644

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -30,8 +30,8 @@ action :build do
   unless ::File.exists?(aurfile)
     Chef::Log.debug("Creating build directory")
     d = directory new_resource.builddir do
-      owner node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      owner node['pacman']['build_user']
+      group node['pacman']['build_user']
       mode 0755
       action :nothing
     end
@@ -40,8 +40,8 @@ action :build do
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
       source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
-      owner node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      owner node['pacman']['build_user']
+      group node['pacman']['build_user']
       mode 0644
       action :nothing
     end
@@ -50,8 +50,8 @@ action :build do
     Chef::Log.debug("Untarring source package for #{new_resource.name}")
     e = execute "tar -xf #{new_resource.name}.tar.gz" do
       cwd new_resource.builddir
-      user node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      user node['pacman']['build_user']
+      group node['pacman']['build_user']
       action :nothing
     end
     e.run_action(:run)
@@ -60,8 +60,8 @@ action :build do
       Chef::Log.debug("Replacing PKGBUILD with custom version")
       pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
         source "PKGBUILD"
-        owner node[:pacman][:build_user]
-        group node[:pacman][:build_user]
+        owner node['pacman']['build_user']
+        group node['pacman']['build_user']
         mode 0644
         action :nothing
       end
@@ -97,8 +97,8 @@ action :build do
     em = execute "makepkg -s --noconfirm #{skippgpcheck}" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
-      user node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      user node['pacman']['build_user']
+      group node['pacman']['build_user']
       action :nothing
     end
     em.run_action(:run)


### PR DESCRIPTION
Hi there,
I'm working on setting up a few Arch nodes at home. This was my first time using Chef to manage Arch nodes and I needed something to manage pacman and particularly to install AUR packages. I naturally came across [jesseadams/pacman-cookbook](https://github.com/jesseadams/pacman) but also noticed that it's outdated and apparently abandoned. I then found your fork but found that it is incompatible with AUR 4.0.0, which moved to a common Git backend last summer: https://wiki.archlinux.org/index.php/Arch_User_Repository#History

I was trying to use the `pacman_aur` resource to install the `aura-bin` package and encountered this error:

```
Recipe: base::arch
  * pacman_aur[aura-bin] action build
    * directory[/var/chef/cache/builds] action create
      - create new directory /var/chef/cache/builds
      - change mode from '' to '0755'
      - change owner from '' to 'nobody'
      - change group from '' to 'nobody'
    * remote_file[/var/chef/cache/builds/aura-bin.tar.gz] action create_if_missing[2016-04-17T16:05:07-04:00] WARN: remote_file[/var/chef/cache/builds/aura-bin.tar.gz] cannot be
downloaded from https://aur.archlinux.org/packages/au/aura-bin/aura-bin.tar.gz: 404 "Not Found"
      ================================================================================
      Error executing action `create_if_missing` on resource 'remote_file[/var/chef/cache/builds/aura-bin.tar.gz]'
      ================================================================================

      Net::HTTPServerException
      ------------------------
      404 "Not Found"

      Cookbook Trace:
      ---------------
      /var/chef/cache/cookbooks/pacman/providers/aur.rb:48:in `block in class_from_file'

      Resource Declaration:
      ---------------------
      # In /var/chef/cache/cookbooks/pacman/providers/aur.rb

       41:     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
       42:       source "https://aur.archlinux.org/packages/#{package_namespace}/#{new_resource.name}/#{new_resource.name}.tar.gz"
       43:       owner node[:pacman][:build_user]
       44:       group node[:pacman][:build_user]
       45:       mode 0644
       46:       action :nothing
       47:     end
       48:     r.run_action(:create_if_missing)

      Compiled Resource:
      ------------------
      # Declared in /var/chef/cache/cookbooks/pacman/providers/aur.rb:41:in `block in class_from_file'

      remote_file("/var/chef/cache/builds/aura-bin.tar.gz") do
        provider Chef::Provider::RemoteFile
        action [:nothing]
        retries 0
        retry_delay 2
        default_guard_interpreter :default
        source ["https://aur.archlinux.org/packages/au/aura-bin/aura-bin.tar.gz"]
        use_etag true
        use_last_modified true
        declared_type :remote_file
        cookbook_name "base"
        owner "nobody"
        group "nobody"
        mode 420
        atomic_update true
        path "/var/chef/cache/builds/aura-bin.tar.gz"
      end
    ================================================================================
    Error executing action `build` on resource 'pacman_aur[aura-bin]'
    ================================================================================

    Net::HTTPServerException
    ------------------------
    remote_file[/var/chef/cache/builds/aura-bin.tar.gz] (/var/chef/cache/cookbooks/pacman/providers/aur.rb line 41) had an error: Net::HTTPServerException: 404 "Not Found"

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/pacman/providers/aur.rb:48:in `block in class_from_file'

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/base/recipes/arch.rb

      2: pacman_aur 'aura-bin' do
      3:   action [:build, :install]
      4: end

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/base/recipes/arch.rb:2:in `from_file'

    pacman_aur("aura-bin") do
      action [:build, :install]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :pacman_aur
      cookbook_name "base"
      recipe_name "arch"
      package_name "aura-bin"
      builddir "/var/chef/cache/builds"
    end


Running handlers:
[2016-04-17T16:05:07-04:00] ERROR: Running exception handlers
Running handlers complete
[2016-04-17T16:05:07-04:00] ERROR: Exception handlers complete
Chef Client failed. 2 resources updated in 25 seconds
[2016-04-17T16:05:07-04:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2016-04-17T16:05:07-04:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2016-04-17T16:05:07-04:00] ERROR: pacman_aur[aura-bin] (base::arch line 2) had an error: Net::HTTPServerException: remote_file[/var/chef/cache/builds/aura-bin.tar.gz] (/var/chef
/cache/cookbooks/pacman/providers/aur.rb line 41) had an error: Net::HTTPServerException: 404 "Not Found"
[2016-04-17T16:05:08-04:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

The fix is easy as you simply have to update the source URL. The snapshot URL looks like it's always in the following format:
`https://aur.archlinux.org/cgit/aur.git/snapshot/<package_name>.tar.gz`

I tested my fix successfully, although in my case I also had to allow the `nobody` user to run `pacman` as a sudoer without a password so it could resolve a dependency, but I figure that shouldn't be part of this cookbook.

I also committed a few stylistic changes to comply with Food Critic rules. 

I figured I would submit this PR to you since the original pacman module is way behind, and maybe some day its maintainer will merge your suggestions, along with mine if you merge this 😄 Let me know if you have any questions!
