### PR TITLE
Add dependency resolution and sync action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.0.0:
+
+- Sets default pacman.build_user to nobody and removes --asroot option, which was removed from pacman in 4.2.0
+
 ## v1.1.1:
 
 - Added --noconfirm to to makepkg runs to not prompt on dependencies (thanks [dvolker](https://github.com/dvolker))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.0.1:
+
+- fix download URL for AUR v4.0.0 (thanks [@fabiendelpierre](https://github.com/fabiendelpierre)!)
+
 ## v2.0.0:
 
 - Sets default pacman.build_user to nobody and removes --asroot option, which was removed from pacman in 4.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'chefspec',   '~> 3.0'
 gem 'foodcritic', '~> 3.0'
 gem 'rubocop',    '~> 0.12'
 
+gem 'open-uri'
+
 group :integration do
   gem 'test-kitchen',    '~> 1.0.0.beta'
   gem 'kitchen-vagrant', '~> 0.11'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ REQUIREMENTS
 
 Platform: ArchLinux. Pacman is not relevant on other platforms.
 
+ATTRIBUTES
+==========
+
+| Attribute                   | Default                                   | Description                                             |
+|-----------------------------|-------------------------------------------|---------------------------------------------------------|
+| `node[:pacman][:build_dir]` | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+
 RESOURCES
 =========
 
@@ -33,7 +40,7 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 ### Parameters:
 
 * version - hardcode a version
-* builddir - specify an alternate build directory, defaults to `Chef::Config[:file_cache_path]/builds`.
+* builddir - specify an alternate build directory, defaults to `node[:pacman][:build_dir]`.
 * options - pass arbitrary options to the pacman command.
 * `pkgbuild_src` - whether to use an included PKGBUILD file, put the PKGBUILD file in in the `files/default` directory.
 * patches - array of patch names, as files in `files/default` that should be applied for the package.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Platform: ArchLinux. Pacman is not relevant on other platforms.
 ATTRIBUTES
 ==========
 
-| Attribute                   | Default                                   | Description                                             |
-|-----------------------------|-------------------------------------------|---------------------------------------------------------|
-| `node[:pacman][:build_dir]` | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| Attribute                    | Default                                   | Description                                             |
+|------------------------------|-------------------------------------------|---------------------------------------------------------|
+| `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| `node[:pacman][:build_user]` | `root`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ATTRIBUTES
 | Attribute                    | Default                                   | Description                                             |
 |------------------------------|-------------------------------------------|---------------------------------------------------------|
 | `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
-| `node[:pacman][:build_user]` | `root`                                    | The user that will build AUR packages.                  |
+| `node[:pacman][:build_user]` | `nobody`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ ATTRIBUTES
 
 | Attribute                    | Default                                   | Description                                             |
 |------------------------------|-------------------------------------------|---------------------------------------------------------|
-| `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
-| `node[:pacman][:build_user]` | `nobody`                                    | The user that will build AUR packages.                  |
+| `node['pacman']['build_dir']`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| `node['pacman']['build_user']` | `nobody`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========
@@ -41,7 +41,7 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 ### Parameters:
 
 * version - hardcode a version
-* builddir - specify an alternate build directory, defaults to `node[:pacman][:build_dir]`.
+* builddir - specify an alternate build directory, defaults to `node['pacman']['build_dir']`.
 * options - pass arbitrary options to the pacman command.
 * `pkgbuild_src` - whether to use an included PKGBUILD file, put the PKGBUILD file in in the `files/default` directory.
 * patches - array of patch names, as files in `files/default` that should be applied for the package.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 * options - pass arbitrary options to the pacman command.
 * `pkgbuild_src` - whether to use an included PKGBUILD file, put the PKGBUILD file in in the `files/default` directory.
 * patches - array of patch names, as files in `files/default` that should be applied for the package.
+* skippgpcheck - optional, pass the `--skippgpcheck` flag to `makepkg`
 
 http://aur.archlinux.org/
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,4 @@
 
 default['pacman']['build_dir'] = "#{Chef::Config[:file_cache_path]}/builds"
 default['pacman']['build_user'] = 'nobody'
+default['pacman']['build_group'] = 'nobody'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
+default[:pacman][:build_user] = "root"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,4 +18,4 @@
 #
 
 default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
-default[:pacman][:build_user] = "root"
+default[:pacman][:build_user] = "nobody"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: pacman
-# Resource:: group
+# Attribute:: default
 #
 # Copyright:: 2010, Opscode, Inc <legal@opscode.com>
 #
@@ -17,14 +17,4 @@
 # limitations under the License.
 #
 
-actions :build, :install
-
-default_action :install
-
-attribute :package_name, :name_attribute => true
-attribute :version, :default => nil
-attribute :builddir, :default => node[:pacman][:build_dir]
-attribute :options, :kind_of => String
-attribute :pkgbuild_src, :default => false
-attribute :patches, :kind_of => Array, :default => []
-attribute :exists, :default => false
+default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
-default[:pacman][:build_user] = "nobody"
+default['pacman']['build_dir'] = "#{Chef::Config[:file_cache_path]}/builds"
+default['pacman']['build_user'] = 'nobody'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.1"
+version          "1.2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.0"
+version          "2.0.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.1"
+version          "2.0.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.2.0"
+version          "2.0.0"

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -105,6 +105,7 @@ def build_aur target, opts
         creates aurfile
         user opts.build_user
         group opts.build_group
+        environment opts.environment
         action :run
     end
 end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -246,7 +246,12 @@ class Package
             {
                 :version => data[0].strip.split[1],
                 :arch => data[1].include?("any") ? "any" : @@default_arch,
-                :dependents => data[2].strip.split[1..-1],
+                :dependents => data[2].strip.split[1..-1].map do |dep|
+                    # TODO: This removes version constraints like the
+                    # apacman package does, in the future, try to follow
+                    # these constraints instead.
+                    dep.match(/[a-z0-9\-_.]+/)[0]
+                end,
             }
         else
             parsed = Package.shell("pacman -Si '#{name}'")

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -19,150 +19,312 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
+require 'tsort'
+require 'open-uri'
 include Chef::Mixin::ShellOut
 
-def build_aur node, new_resource
-  get_pkg_version
-  aurfile = "#{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
-  package_namespace = new_resource.name[0..1]
+def aurfile_path target, build_dir
+    target_build = ::File.join build_dir, target.name, target.name
+    aurfiles = ::Dir["#{target_build}-*.pkg.tar.xz"]
+    if aurfiles.length == 0
+        "#{target_build}-#{target.version}-#{target.arch}.pkg.tar.xz"
+    else
+        aurfiles[0]
+    end
+end
 
-  Chef::Log.debug("Checking for #{aurfile}")
-  unless ::File.exists?(aurfile)
+def already_built? target, build_dir
+    ::File.exists? aurfile_path(target, build_dir)
+end
+
+def build_aur target, opts
+    pkgbuild = ::File.join opts.build_dir, target.name, "PKGBUILD"
+    aurfile = aurfile_path target, opts.build_dir
+
     Chef::Log.debug("Creating build directory")
-    d = directory new_resource.builddir do
-      owner node['pacman']['build_user']
-      group node['pacman']['build_user']
-      mode 0755
-      action :nothing
+    directory "build_dir_#{target.name}" do
+        path opts.build_dir
+        owner opts.build_user
+        group opts.build_group
+        mode 0755
+        action :create
     end
-    d.run_action(:create)
 
-    Chef::Log.debug("Retrieving source for #{new_resource.name}")
-    r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
-      source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
-      owner node['pacman']['build_user']
-      group node['pacman']['build_user']
-      mode 0644
-      action :nothing
-    end
-    r.run_action(:create_if_missing)
-
-    Chef::Log.debug("Untarring source package for #{new_resource.name}")
-    e = execute "tar -xf #{new_resource.name}.tar.gz" do
-      cwd new_resource.builddir
-      user node['pacman']['build_user']
-      group node['pacman']['build_user']
-      action :nothing
-    end
-    e.run_action(:run)
-
-    if new_resource.pkgbuild_src
-      Chef::Log.debug("Replacing PKGBUILD with custom version")
-      pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
-        source "PKGBUILD"
-        owner node['pacman']['build_user']
-        group node['pacman']['build_user']
+    Chef::Log.debug("Retrieving source for #{target.name}")
+    remote_file ::File.join opts.build_dir, "#{target.name}.tar.gz" do
+        source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{target.name}.tar.gz"
+        owner opts.build_user
+        group opts.build_group
         mode 0644
-        action :nothing
-      end
-      pkgb.run_action(:create)
+        action :create_if_missing
     end
 
-    if new_resource.patches.length > 0
-      Chef::Log.debug("Adding new patches")
-      new_resource.patches.each do |patch|
-        pfile = cookbook_file ::File.join(new_resource.builddir, new_resource.name, patch) do
-          source patch
-          mode 0644
-          action :nothing
+    Chef::Log.debug("Untarring source package for #{target.name}")
+    execute "tar -xf #{target.name}.tar.gz" do
+        cwd opts.build_dir
+        user opts.build_user
+        group opts.build_group
+        action :run
+    end
+
+    if opts.pkgbuild_src
+        Chef::Log.debug("Replacing PKGBUILD with custom version")
+        cookbook_file pkgbuild do
+            source "PKGBUILD"
+            owner opts.build_user
+            group opts.build_group
+            mode 0644
+            action :create
         end
-        pfile.run_action(:create)
-      end
+    end
+
+    if opts.patches.length > 0
+        Chef::Log.debug("Adding new patches")
+        opts.patches.each do |patch|
+            cookbook_file ::File.join opts.build_dir, target.name, patch do
+                source patch
+                mode 0644
+                action :create
+            end
+        end
     end
 
     if new_resource.options
-      Chef::Log.debug("Appending #{new_resource.options} to configure command")
-      opt = Chef::Util::FileEdit.new("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD")
-      opt.search_file_replace(/(.\/configure.+$)/, "\\1 #{new_resource.options}")
-      opt.write_file
+        Chef::Log.debug("Appending #{opts.options} to configure command")
+        opt = Chef::Util::FileEdit.new pkgbuild
+        opt.search_file_replace(/(.\/configure.+$)/, "\\1 #{opts.options}")
+        opt.write_file
     end
 
-    if new_resource.skippgpcheck
-      skippgpcheck = ' --skippgpcheck'
-    else
-      ''
-    end
+    skippgpcheck = opts.skippgpcheck ? " --skippgpcheck" : ""
 
-    Chef::Log.debug("Building package #{new_resource.name}")
-    em = execute "makepkg -s --noconfirm #{skippgpcheck}" do
-      cwd ::File.join(new_resource.builddir, new_resource.name)
-      creates aurfile
-      user node['pacman']['build_user']
-      group node['pacman']['build_user']
-      action :nothing
+    Chef::Log.debug("Building package #{target.name}")
+    execute "makepkg #{target.name}" do
+        command "makepkg -sf --noconfirm#{skippgpcheck}"
+        cwd ::File.join opts.build_dir, target.name
+        creates aurfile
+        user opts.build_user
+        group opts.build_group
+        action :run
     end
-    em.run_action(:run)
-    new_resource.updated_by_last_action(true)
-  end
 end
 
-def install_aur new_resource
-  get_pkg_version
-
-  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
-    execute "install AUR package #{new_resource.name}-#{new_resource.version}" do
-      command "pacman -U --noconfirm  --noprogressbar #{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
+def install_aur target, opts
+    execute "install AUR package #{target.name}" do
+        command lazy {
+            aurfile = aurfile_path target, opts.build_dir
+            "pacman -U --noconfirm  --noprogressbar #{aurfile}"
+        }
     end
-    new_resource.updated_by_last_action(true)
-  end
+end
+
+def install_with_deps target, opts
+    deps = target.all_dependencies.ordered
+    deps.reject { |p| p.already_installed? }
+    .each do |package|
+        Chef::Log.debug("Installing #{package} as a dependency of #{target}")
+        if package.is_aur?
+            if not already_built? package, opts.build_dir
+                build_aur package, opts
+            end
+            install_aur package, opts
+        else
+            pacman_package package.name
+        end
+    end
 end
 
 action :build do
-  build_aur node, new_resource
+    target = Package.aur new_resource.package_name
+    opts = new_resource
+
+    Chef::Log.debug("Checking for #{aurfile_path target, opts.build_dir}")
+    if not already_built? target, build_dir
+        build_aur target, opts
+        new_resource.updated_by_last_action true
+    end
 end
 
 action :install do
-  install_aur new_resource
+    target = Package.aur new_resource.package_name
+    if not target.already_installed?
+        install_aur target, new_resource
+        new_resource.updated_by_last_action true
+    end
 end
 
 action :sync do
-  load_current_resource
-  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
-    build_aur node, new_resource
-    install_aur new_resource
-  end
-end
-
-def get_pkg_version
-  v = ''
-  r = ''
-  a = ''
-  if ::File.exists?("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD")
-    ::File.open("#{new_resource.builddir}/#{new_resource.name}/PKGBUILD").each do |line|
-      v = line.split("=")[1].chomp if line =~ /^pkgver=/
-      r = line.split("=")[1].chomp if line =~ /^pkgrel=/
-      if line =~ /^arch/
-        if line.match 'any'
-          a = 'any'
-        else
-          a = node[:kernel][:machine]
-        end
-      end
+    target = Package.aur new_resource.package_name
+    if not target.already_installed?
+        install_with_deps target, new_resource
+        new_resource.updated_by_last_action true
     end
-    Chef::Log.debug("Setting version of #{new_resource.name} to #{v}-#{r}-#{a}")
-    new_resource.version("#{v}-#{r}-#{a}")
-  end
 end
 
-def load_current_resource
-  @aurpkg = Chef::Resource::PacmanAur.new(new_resource.name)
-  @aurpkg.package_name(new_resource.package_name)
+class Package
+    attr_reader :name, :version, :arch, :dependents
 
-  Chef::Log.debug("Checking pacman for #{new_resource.package_name}")
-  p = shell_out("pacman -Qi #{new_resource.package_name}")
-  exists = p.stdout.include?(new_resource.package_name)
-  @aurpkg.exists(exists)
-  p.stdout.match(/Version +: ([\w.-]+).+Architecture +: (\w+)/m) do |match|
-    @aurpkg.installed_version("#{match[1]}-#{match[2]}")
-  end
+    @@version_arch_re = /Version +: ([\w.-]+).+Architecture +: (\w+)/m
+    @@default_arch = RUBY_PLATFORM.split("-")[0]
+
+    def initialize name, is_aur
+        info = Package.fetch_latest_info name, is_aur
+        @name = name
+        @is_aur = is_aur
+        @version = info[:version]
+        @arch = info[:arch]
+        @dependents = info[:dependents]
+        @installed = Package.installed_info name
+    end
+
+    def self.aur name
+        Package.new name, true
+    end
+
+    def self.pacman name
+        Package.new name, false
+    end
+
+    def to_s
+        if @is_aur
+            "Aur(#{@name}-#{@version})"
+        else
+            "Pacman(#{@name}-#{@version})"
+        end
+    end
+
+    def eql? other
+        @name == other.name
+    end
+
+    def hash
+        @name.hash
+    end
+
+    def is_aur?
+        @is_aur
+    end
+
+    def already_installed?
+        @installed && @version == @installed[:version]
+    end
+
+    def all_dependencies
+        AurDeps.new self
+    end
+
+    private
+
+    def self.pkgbuild_url name
+        "https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=#{name}"
+    end
+
+    def self.shell command
+        Mixlib::ShellOut.new(command,
+            :user => "nobody",
+            :group => "nobody",
+            :cwd => "/tmp",
+        ).run_command.stdout.strip
+    end
+
+    def self.fetch_latest_info name, is_aur
+        if is_aur
+            pkgbuild = open(Package.pkgbuild_url name).read
+            command = <<-FIN
+                #{pkgbuild}
+                echo
+                echo version ${pkgver}-${pkgrel}
+                echo arch ${arch}
+                echo depends ${depends[@]} ${makedepends[@]}
+            FIN
+            parser = Mixlib::ShellOut.new(command,
+                :user => "nobody",
+                :group => "nobody",
+                :cwd => "/tmp",
+                :timeout => 1)
+            data = parser.run_command.stdout.strip.split("\n").last 3
+            {
+                :version => data[0].strip.split[1],
+                :arch => data[1].include?("any") ? "any" : @@default_arch,
+                :dependents => data[2].strip.split[1..-1],
+            }
+        else
+            parsed = Package.shell("pacman -Si '#{name}'")
+                .match(@@version_arch_re)
+            if parsed && parsed.length == 3
+                {
+                    :version => parsed[1],
+                    :arch => parsed[2],
+                    # pacman can handle its own dependencies!
+                    :dependents => [],
+                }
+            end
+        end
+    end
+
+    def self.installed_info name
+        Chef::Log.debug("Checking pacman for #{name}")
+        parsed = Package.shell("pacman -Qi '#{name}'").match(@@version_arch_re)
+        if parsed && parsed.length == 3
+            {
+                :version => parsed[1],
+                :arch => parsed[2],
+            }
+        else
+            false
+        end
+    end
+end
+
+class AurDeps
+    include TSort
+
+    def initialize package
+        @package = package
+        @deps = build_dag @package
+    end
+
+    def tsort_each_node &block
+        @deps.each_key(&block)
+    end
+
+    def tsort_each_child name, &block
+        @deps[name].each(&block)
+    end
+
+    def build_dag source
+        deps = {}
+        queue = [source]
+        while not queue.empty?
+            package = queue.shift
+            dependents = package.dependents.map do |dependent|
+                found = Package.shell("pacman -Si #{dependent}").length != 0
+                if !found
+                    out = Package.shell("pacman -Ssq '^#{dependent}$'")
+                    providers = out.split "\n"
+                    if providers.length != 0
+                        # TODO: Support muliple providers
+                        dependent = providers[0]
+                        found = true
+                    end
+                end
+                Package.new dependent, !found
+            end
+            deps[package] = dependents
+            queue += dependents
+        end
+        deps
+    end
+
+    def to_s
+        printed = {}
+        @deps.keys.each do |key|
+            printed[key.to_s] = @deps[key].map { |p| p.to_s }
+        end
+        printed
+    end
+
+    def ordered
+        tsort
+    end
 end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -123,7 +123,7 @@ def get_pkg_version
         if line.match 'any'
           a = 'any'
         else
-          a = node.kernel.machine
+          a = node[:kernel][:machine]
         end
       end
     end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -102,8 +102,9 @@ action :build do
 end
 
 action :install do
-  unless @aurpkg.exists
-    get_pkg_version
+  get_pkg_version
+
+  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
     execute "install AUR package #{new_resource.name}-#{new_resource.version}" do
       command "pacman -U --noconfirm  --noprogressbar #{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
     end
@@ -140,4 +141,7 @@ def load_current_resource
   p = shell_out("pacman -Qi #{new_resource.package_name}")
   exists = p.stdout.include?(new_resource.package_name)
   @aurpkg.exists(exists)
+  p.stdout.match(/Version +: ([\w.-]+).+Architecture +: (\w+)/m) do |match|
+    @aurpkg.installed_version("#{match[1]}-#{match[2]}")
+  end
 end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -88,8 +88,7 @@ action :build do
     end
 
     Chef::Log.debug("Building package #{new_resource.name}")
-    as_root = node[:pacman][:build_user] == "root" ? " --asroot" : ""
-    em = execute "makepkg -s --noconfirm#{as_root}" do
+    em = execute "makepkg -s --noconfirm" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
       user node[:pacman][:build_user]

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -30,8 +30,8 @@ action :build do
   unless ::File.exists?(aurfile)
     Chef::Log.debug("Creating build directory")
     d = directory new_resource.builddir do
-      owner "root"
-      group "root"
+      owner node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       mode 0755
       action :nothing
     end
@@ -40,8 +40,8 @@ action :build do
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
       source "https://aur.archlinux.org/packages/#{package_namespace}/#{new_resource.name}/#{new_resource.name}.tar.gz"
-      owner "root"
-      group "root"
+      owner node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       mode 0644
       action :nothing
     end
@@ -50,6 +50,8 @@ action :build do
     Chef::Log.debug("Untarring source package for #{new_resource.name}")
     e = execute "tar -xf #{new_resource.name}.tar.gz" do
       cwd new_resource.builddir
+      user node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       action :nothing
     end
     e.run_action(:run)
@@ -58,8 +60,8 @@ action :build do
       Chef::Log.debug("Replacing PKGBUILD with custom version")
       pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
         source "PKGBUILD"
-        owner "root"
-        group "root"
+        owner node[:pacman][:build_user]
+        group node[:pacman][:build_user]
         mode 0644
         action :nothing
       end
@@ -86,9 +88,12 @@ action :build do
     end
 
     Chef::Log.debug("Building package #{new_resource.name}")
-    em = execute "makepkg -s --asroot --noconfirm" do
+    as_root = node[:pacman][:build_user] == "root" ? " --asroot" : ""
+    em = execute "makepkg -s --noconfirm#{as_root}" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
+      user node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       action :nothing
     end
     em.run_action(:run)

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -39,7 +39,7 @@ action :build do
 
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
-      source "https://aur.archlinux.org/packages/#{package_namespace}/#{new_resource.name}/#{new_resource.name}.tar.gz"
+      source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
       owner node[:pacman][:build_user]
       group node[:pacman][:build_user]
       mode 0644

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -87,8 +87,14 @@ action :build do
       opt.write_file
     end
 
+    if new_resource.skippgpcheck
+      skippgpcheck = ' --skippgpcheck'
+    else
+      ''
+    end
+
     Chef::Log.debug("Building package #{new_resource.name}")
-    em = execute "makepkg -s --noconfirm" do
+    em = execute "makepkg -s --noconfirm #{skippgpcheck}" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
       user node[:pacman][:build_user]

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -30,8 +30,8 @@ action :build do
   unless ::File.exists?(aurfile)
     Chef::Log.debug("Creating build directory")
     d = directory new_resource.builddir do
-      owner node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      owner node['pacman']['build_user']
+      group node['pacman']['build_user']
       mode 0755
       action :nothing
     end
@@ -40,8 +40,8 @@ action :build do
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
       source "https://aur.archlinux.org/cgit/aur.git/snapshot/#{new_resource.name}.tar.gz"
-      owner node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      owner node['pacman']['build_user']
+      group node['pacman']['build_user']
       mode 0644
       action :nothing
     end
@@ -50,8 +50,8 @@ action :build do
     Chef::Log.debug("Untarring source package for #{new_resource.name}")
     e = execute "tar -xf #{new_resource.name}.tar.gz" do
       cwd new_resource.builddir
-      user node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      user node['pacman']['build_user']
+      group node['pacman']['build_user']
       action :nothing
     end
     e.run_action(:run)
@@ -60,8 +60,8 @@ action :build do
       Chef::Log.debug("Replacing PKGBUILD with custom version")
       pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
         source "PKGBUILD"
-        owner node[:pacman][:build_user]
-        group node[:pacman][:build_user]
+        owner node['pacman']['build_user']
+        group node['pacman']['build_user']
         mode 0644
         action :nothing
       end
@@ -97,8 +97,8 @@ action :build do
     em = execute "makepkg -s --noconfirm #{skippgpcheck}" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
-      user node[:pacman][:build_user]
-      group node[:pacman][:build_user]
+      user node['pacman']['build_user']
+      group node['pacman']['build_user']
       action :nothing
     end
     em.run_action(:run)

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -19,12 +19,13 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
+include Chef::Mixin::Command
 include Chef::Mixin::ShellOut
 
 action :install do
   unless @pmgroup.exists
     run_command_with_systems_locale(
-      :command => "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}"
+      :command => "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{@new_resource.name}"
     )
     new_resource.updated_by_last_action(true)
   end
@@ -33,7 +34,7 @@ end
 action :remove do
   if @pmgroup.exists
     run_command_with_systems_locale(
-      :command => "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}"
+      :command => "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{@new_resource.name}"
     )
     new_resource.updated_by_last_action(true)
   end
@@ -47,4 +48,9 @@ def load_current_resource
   p = shell_out("pacman -Qg #{@new_resource.package_name}")
   exists = p.stdout.include?(@new_resource.package_name)
   @pmgroup.exists(exists)
+end
+
+# From Chef::Provider::Package
+def expand_options(options)
+  options ? " #{options}" : ""
 end

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :build, :install
+actions :build, :install, :sync
 
 default_action :install
 

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -29,6 +29,7 @@ attribute :build_group, :default => node[:pacman][:build_group]
 attribute :options, :kind_of => String
 attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []
+attribute :environment, :kind_of => Hash, :default => {}
 attribute :exists, :default => false
 attribute :installed_version, :default => nil
 attribute :skippgpcheck, :default => false

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -23,7 +23,9 @@ default_action :install
 
 attribute :package_name, :name_attribute => true
 attribute :version, :default => nil
-attribute :builddir, :default => node[:pacman][:build_dir]
+attribute :build_dir, :default => node[:pacman][:build_dir]
+attribute :build_user, :default => node[:pacman][:build_user]
+attribute :build_group, :default => node[:pacman][:build_group]
 attribute :options, :kind_of => String
 attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -28,3 +28,4 @@ attribute :options, :kind_of => String
 attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []
 attribute :exists, :default => false
+attribute :installed_version, :default => nil

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -29,3 +29,4 @@ attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []
 attribute :exists, :default => false
 attribute :installed_version, :default => nil
+attribute :skippgpcheck, :default => false


### PR DESCRIPTION
This PR adds the ability to resolve aur and pacman dependencies for aur packages and add the sync
action, which will build and install the package if it is not already installed.

This did require quite a bit of refactoring, so I imagine that someone will have opinions about it.
I am **very** new to ruby, so some things might not be idiomatic ruby.
